### PR TITLE
Allow direct requirement

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -1,10 +1,10 @@
-var split = require('./split');
+var Split = require('./split');
 
 // Based on Melbourne Cup 2015
 // http://www.races.com.au/melbourne-cup/melbourne-cup-history/facts-and-statistics/
 
 //Create a new instance of split
-var split = new split.Split(100); // pass Split the total amount you want to spend on the event.
+var split = new Split(100); // pass Split the total amount you want to spend on the event.
 
 // Add each competitor to the event, with their ID and Odds
 split.addItem(1, 51);   // SNOW SKY (16)

--- a/split.js
+++ b/split.js
@@ -158,6 +158,4 @@ Split.prototype.winning = function() {
 };
 
 // Exports for nodejs
-module.exports = {
-    Split: Split
-};
+module.exports = Split;


### PR DESCRIPTION
This change allows us to do this:

```
var Split = require('./split');
var s = new Split();
```

Rather than:

```
var Split = require('./split').Split;
var s = new Split();
```

or

```
var Split = require('./split');
var s = new Split.Split();
```
